### PR TITLE
issue 431

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,6 @@ build:
 publish:
   image: "${BUILDER_IMAGE}"
   stage: publish
-  retry: 2
   only:
     - main
   script:


### PR DESCRIPTION
Relates to https://github.com/kubefirst/kubefirst/issues/431 We can't retry the full workflow, some steps will fail if re-executed. 
ie: image creation


- https://github.com/kubefirst/kubefirst/issues/431 

Details on internal discussion,  but we should prefer retry logic on the cwft actions, not the full workflow, this produce "un-retrialble state". 

Example: https://github.com/kubefirst/gitops-template/blob/main/components/argo-cwfts/cwft-helm.yaml#L9